### PR TITLE
feat(azure_devops): AzureRM endpoint declared

### DIFF
--- a/infrastructure/azuredevops/main.tf
+++ b/infrastructure/azuredevops/main.tf
@@ -5,9 +5,22 @@ resource "azuredevops_project" "blog" {
   work_item_template = "Basic"
   description        = "Managed by Terraform"
   features = {
-    "boards"       = "disabled"
+    "boards"       = "enabled"
     "repositories" = "disabled"
     "testplans"    = "disabled"
     "artifacts"    = "disabled"
   }
+}
+
+resource "azuredevops_serviceendpoint_azurerm" "azure" {
+  project_id            = azuredevops_project.blog.id
+  service_endpoint_name = "Azure Cloud"
+  description           = "Managed by Terraform"
+  credentials {
+    serviceprincipalid  = var.client_id
+    serviceprincipalkey = var.client_secret
+  }
+  azurerm_spn_tenantid      = var.tenant_id
+  azurerm_subscription_id   = var.subscription_id
+  azurerm_subscription_name = "Pay-As-You-Go"
 }


### PR DESCRIPTION
# AzureRM endpoint declared

A manual AzureRM Service Endpoint (Subscription Scoped) resource was declared.

## Azure DevOps project resource

I was forced to redeploy the Azure DevOps project resource because initially, I disabled the Azure Boards completely. But the Azure DevOps Terraform provider requires the project template ID that is only provided when the boards are enabled.

More information about this behavior can be found here: https://github.com/microsoft/terraform-provider-azuredevops/issues/199

GitHub Item: #1 
